### PR TITLE
freeze revbayes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	branch = dev
 [submodule "lib/revbayes"]
 	path = lib/revbayes
-	url = https://github.com/revbayes/revbayes.git
+	url = https://github.com/eharkins/revbayes.git
 [submodule "lib/phylomd"]
 	path = lib/phylomd
 	url = https://github.com/dunleavy005/phylomd.git


### PR DESCRIPTION
move from https://github.com/revbayes/revbayes/tree/2779aeeaa68a0ff5efe189b8508e17536e301e60
to 
https://github.com/eharkins/revbayes/tree/linearham-stable-commit
in order to freeze at the commit we have been using as the official revbayes repo moves / gets archived