### PR TITLE
92 revbayes base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,16 +19,16 @@ jobs:
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+    - name: Login to Registry
+      run: docker login quay.io -u ${{ secrets.QUAY_USERNAME }} --password ${{ secrets.QUAY_PASSWORD }}
     - name: Build the Docker image
       run: docker build . -t quay.io/matsengrp/linearham:$TAG
     - name: Run tests in the Docker image
       run: docker run quay.io/matsengrp/linearham:$TAG sh -c "/linearham/_build/test/test"
     - name: Run example in the Docker image
       run: docker run --rm quay.io/matsengrp/linearham:$TAG sh -c "/linearham/test.sh && /linearham/clean.sh"
-    - name: Login to Registry
-      run: docker login quay.io -u ${{ secrets.QUAY_USERNAME }} --password ${{ secrets.QUAY_PASSWORD }}
-    - name: publish to Registry
-      run: docker push quay.io/matsengrp/linearham:$TAG
+      #- name: publish to Registry
+      #  run: docker push quay.io/matsengrp/linearham:$TAG
     - name: Build documentation
       run: docker run --rm -v $(pwd):/data nakatt/doxygen:1.8.17 Doxyfile
     - name: Deploy to GitHub Pages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jitesoft/debian:stretch
+FROM quay.io/matsengrp/linearham/2022-11-29-base-image
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   autoconf \
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   less \
   wget \
   git
+
 RUN wget https://mafft.cbrc.jp/alignment/software/mafft_7.450-1_amd64.deb && dpkg -i mafft_7.450-1_amd64.deb
 RUN Rscript --slave --vanilla -e 'install.packages(c("phylotate", "Rcpp", "RcppArmadillo"), repos = "https://cloud.r-project.org")'
 
@@ -40,7 +41,7 @@ WORKDIR /linearham
 RUN pip install wheel
 RUN pip install -r requirements.txt
 RUN Rscript --slave --vanilla -e 'install.packages("lib/phylomd", repos = NULL, type = "source")'
-RUN cd lib/revbayes/projects/cmake && ./build.sh
+# RUN cd lib/revbayes/projects/cmake && ./build.sh
 RUN scons --build-partis-linearham && ./clean.sh
 
 CMD ./test.sh && ./clean.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/matsengrp/linearham/2022-11-29-base-image
+FROM quay.io/matsengrp/linearham:2022-11-29-base-image
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ WORKDIR /linearham
 RUN pip install wheel
 RUN pip install -r requirements.txt
 RUN Rscript --slave --vanilla -e 'install.packages("lib/phylomd", repos = NULL, type = "source")'
-# RUN cd lib/revbayes/projects/cmake && ./build.sh
 RUN scons --build-partis-linearham && ./clean.sh
 
 CMD ./test.sh && ./clean.sh


### PR DESCRIPTION
This PR updates the docker file to use a new base image (which I've build locally and committed to `quay.io/matsengrp/linearham:2022-11-29-base-image`), that already has revbayes installed. With this updated base image, we expect any triggers set up on [quay to run successfully](https://quay.io/repository/matsengrp/linearham/build/861a9291-6643-4fbf-a02c-5c5f6435a4ba) an thus I've disabled the publish step to quay in the [build gh action](https://github.com/matsengrp/linearham/blob/7a679b1b3619acefecdcf316075c53bc726c79a4/.github/workflows/build.yml#L30).

Merging this should close #92 